### PR TITLE
fix: missing newline when using license checker in pyproject

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -74,8 +74,8 @@ testpaths = [
     "tests",
     "src/{{cookiecutter.project_name}}",
 ]
+{{"\n" if cookiecutter.license_checker != "n" else ""}}
 {%- if cookiecutter.license_checker != "n" -%}
-
 [tool.pylic]
 safe_licenses = [
     "1-clause BSD License",


### PR DESCRIPTION
Add missing newline when using license checker in the same way as in `pre-commit-config.yaml`.