### PR TITLE
Pyproject fix pip

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -23,7 +23,7 @@ build-backend = "{{'poetry.core.masonry.api' if cookiecutter.dependency_manager 
 {{'mypy = ">=1.9.0"'       if cookiecutter.dependency_manager != 'pip' else ' "mypy==1.9.0",'}}
 {{'nbstripout = ">=0.7.1"' if cookiecutter.dependency_manager != 'pip' else ' "nbstripout==0.7.1",'}}
 {{''                       if cookiecutter.dependency_manager != 'pip' else ' "coverage[toml]==5.5",'}}
-{{'[[tool.poetry.source]]\nname = "pypi" if cookiecutter.dependency_manager != 'pip' else ']'}}
+{{'[[tool.poetry.source]]\nname = "pypi"' if cookiecutter.dependency_manager != 'pip' else ']'}}
 
 [tool.ruff]
 target-version = "{{'py312' if cookiecutter.python_version == '3.12'}}{{'py311' if cookiecutter.python_version == '3.11'}}{{'py310' if cookiecutter.python_version == '3.10'}}{{'py39' if cookiecutter.python_version == '3.9'}}{{'py38' if cookiecutter.python_version == '3.8'}}{{'py37' if cookiecutter.python_version == '3.7'}}"

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -12,7 +12,6 @@ requires = [
 ]
 build-backend = "{{'poetry.core.masonry.api' if cookiecutter.dependency_manager != 'pip' else 'setuptools.build_meta'}}"
 {{'\n[project.license]\nfile = "LICENSE"\n' if cookiecutter.dependency_manager == 'pip'}}
-
 {{'[tool.poetry.group.dev.dependencies]' if cookiecutter.dependency_manager != 'pip' else '[project.optional-dependencies]\ndev = ['}}
 {{'pytest = ">=8.1.1"'     if cookiecutter.dependency_manager != 'pip' else ' "pytest==8.1.1",'}}
 {{'pytest-cov = ">=4.1.0"' if cookiecutter.dependency_manager != 'pip' else ' "pytest-cov==4.1.0",'}}

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -18,13 +18,12 @@ build-backend = "{{'poetry.core.masonry.api' if cookiecutter.dependency_manager 
 {{'pytest-cov = ">=4.1.0"' if cookiecutter.dependency_manager != 'pip' else ' "pytest-cov==4.1.0",'}}
 {{'pre-commit = ">=3.6.2"' if cookiecutter.dependency_manager != 'pip' else ' "pre-commit==3.6.2",'}}
 {{'pdoc = ">=14.1.0"'      if cookiecutter.dependency_manager != 'pip' else ' "pdoc==14.1.0",'}}
-
 {{'readme-coverage-badger = ">=0.1.2"' if cookiecutter.dependency_manager != 'pip' else ' "readme-coverage-badger==0.1.2",'}}
 {{'click = ">=8.1.7"'      if cookiecutter.dependency_manager != 'pip' else ' "click==8.1.7",'}}
 {{'ruff = ">=0.3.2"'       if cookiecutter.dependency_manager != 'pip' else ' "ruff==0.3.2",'}}
 {{'mypy = ">=1.9.0"'       if cookiecutter.dependency_manager != 'pip' else ' "mypy==1.9.0",'}}
-{{''                       if cookiecutter.dependency_manager != 'pip' else ' "coverage[toml]==5.5",'}}
 {{'nbstripout = ">=0.7.1"' if cookiecutter.dependency_manager != 'pip' else ' "nbstripout==0.7.1",'}}
+{{''                       if cookiecutter.dependency_manager != 'pip' else ' "coverage[toml]==5.5",'}}
 {{'\n' if cookiecutter.dependency_manager != 'pip' else '\n]'}}
 {{'\n[[tool.poetry.source]]\nname = "pypi"' if cookiecutter.dependency_manager != 'pip'}}
 

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -23,8 +23,7 @@ build-backend = "{{'poetry.core.masonry.api' if cookiecutter.dependency_manager 
 {{'mypy = ">=1.9.0"'       if cookiecutter.dependency_manager != 'pip' else ' "mypy==1.9.0",'}}
 {{'nbstripout = ">=0.7.1"' if cookiecutter.dependency_manager != 'pip' else ' "nbstripout==0.7.1",'}}
 {{''                       if cookiecutter.dependency_manager != 'pip' else ' "coverage[toml]==5.5",'}}
-{{'\n' if cookiecutter.dependency_manager != 'pip' else '\n]'}}
-{{'\n[[tool.poetry.source]]\nname = "pypi"' if cookiecutter.dependency_manager != 'pip'}}
+{{'[[tool.poetry.source]]\nname = "pypi" if cookiecutter.dependency_manager != 'pip' else ']'}}
 
 [tool.ruff]
 target-version = "{{'py312' if cookiecutter.python_version == '3.12'}}{{'py311' if cookiecutter.python_version == '3.11'}}{{'py310' if cookiecutter.python_version == '3.10'}}{{'py39' if cookiecutter.python_version == '3.9'}}{{'py38' if cookiecutter.python_version == '3.8'}}{{'py37' if cookiecutter.python_version == '3.7'}}"

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -12,16 +12,20 @@ requires = [
 ]
 build-backend = "{{'poetry.core.masonry.api' if cookiecutter.dependency_manager != 'pip' else 'setuptools.build_meta'}}"
 {{'\n[project.license]\nfile = "LICENSE"\n' if cookiecutter.dependency_manager == 'pip'}}
+
 {{'[tool.poetry.group.dev.dependencies]' if cookiecutter.dependency_manager != 'pip' else '[project.optional-dependencies]\ndev = ['}}
-{{'pytest = ">=8.1.1"' if cookiecutter.dependency_manager != 'pip' else ' "pytest==8.1.1",'}}
-{{'pytest-cov = ">=4.1.0"' if cookiecutter.dependency_manager != 'pip' else '    "pytest-cov==4.1.0",'}}
-{{'pre-commit = ">=3.6.2"' if cookiecutter.dependency_manager != 'pip' else '    "pre-commit==3.6.2",'}}
-{{'pdoc = ">=14.1.0"' if cookiecutter.dependency_manager != 'pip' else '    "pdoc==14.1.0",'}}
-{{'' if cookiecutter.dependency_manager != 'pip' else '    "coverage[toml]==5.5",'}}{{'readme-coverage-badger = ">=0.1.2"' if cookiecutter.dependency_manager != 'pip' else '\n    "readme-coverage-badger==0.1.2",'}}
-{{'click = ">=8.1.7"' if cookiecutter.dependency_manager != 'pip' else '    "click==8.1.7",\n]'}}
-{{'ruff = ">=0.3.2"' if cookiecutter.dependency_manager != 'pip' else '    "ruff==0.3.2",\n]'}}
-{{'mypy = ">=1.9.0"' if cookiecutter.dependency_manager != 'pip' else '    "mypy==1.9.0",\n]'}}
-{{'nbstripout = ">=0.7.1"' if cookiecutter.dependency_manager != 'pip' else ' "nbstripout==0.7.1",\n]'}}
+{{'pytest = ">=8.1.1"'     if cookiecutter.dependency_manager != 'pip' else ' "pytest==8.1.1",'}}
+{{'pytest-cov = ">=4.1.0"' if cookiecutter.dependency_manager != 'pip' else ' "pytest-cov==4.1.0",'}}
+{{'pre-commit = ">=3.6.2"' if cookiecutter.dependency_manager != 'pip' else ' "pre-commit==3.6.2",'}}
+{{'pdoc = ">=14.1.0"'      if cookiecutter.dependency_manager != 'pip' else ' "pdoc==14.1.0",'}}
+
+{{'readme-coverage-badger = ">=0.1.2"' if cookiecutter.dependency_manager != 'pip' else ' "readme-coverage-badger==0.1.2",'}}
+{{'click = ">=8.1.7"'      if cookiecutter.dependency_manager != 'pip' else ' "click==8.1.7",'}}
+{{'ruff = ">=0.3.2"'       if cookiecutter.dependency_manager != 'pip' else ' "ruff==0.3.2",'}}
+{{'mypy = ">=1.9.0"'       if cookiecutter.dependency_manager != 'pip' else ' "mypy==1.9.0",'}}
+{{''                       if cookiecutter.dependency_manager != 'pip' else ' "coverage[toml]==5.5",'}}
+{{'nbstripout = ">=0.7.1"' if cookiecutter.dependency_manager != 'pip' else ' "nbstripout==0.7.1",'}}
+{{'\n' if cookiecutter.dependency_manager != 'pip' else '\n]'}}
 {{'\n[[tool.poetry.source]]\nname = "pypi"' if cookiecutter.dependency_manager != 'pip'}}
 
 [tool.ruff]


### PR DESCRIPTION
There were a couple of dev-dependencies lines in `pyproject.toml` which included a superfluous `]` character, which led to the pyproject.toml being misparsed during installation.

With this fix, the project works again for pip, and still works for poetry.