### PR TITLE
chore: Add dependabot.yaml

### DIFF
--- a/{{cookiecutter.project_name}}/dependabot.yaml
+++ b/{{cookiecutter.project_name}}/dependabot.yaml
@@ -1,0 +1,9 @@
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Adds a dependabot config, which will enable automatic PRs with updates to package versions in both Github actions as well as `pyproject.toml`/`requirements.txt` files.

Closes #16.