### PR TITLE
Make pre-commit really optional

### DIFF
--- a/{{cookiecutter.project_name}}/makefile
+++ b/{{cookiecutter.project_name}}/makefile
@@ -34,7 +34,6 @@ install: ## Install dependencies
 	@$(MAKE) --quiet setup-environment-variables
 	@$(MAKE) --quiet setup-git
 	@$(MAKE) --quiet install-pre-commit
-	@$(MAKE) --quiet add-repo-to-git
 	@echo "Installed the '{{ cookiecutter.project_name }}' project! You can now activate your virtual environment with 'source .venv/bin/activate'."
 	@echo "Note that this is a 'uv' project. Use 'uv add <package>' to install new dependencies and 'uv remove <package>' to remove them."
 


### PR DESCRIPTION
If the README says that the pre-commit hook is optional, `make pre-commit` option should probably not be part of `make install`.